### PR TITLE
Publishing device metadata

### DIFF
--- a/.github/docker-build-push.yml
+++ b/.github/docker-build-push.yml
@@ -1,0 +1,29 @@
+name: Build and Push Docker Image to Docker Hub
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/atd-trail-counters:production
+            ${{ secrets.DOCKER_USERNAME }}/atd-trail-counters:latest


### PR DESCRIPTION
Changing this ETL to pull out device location data into this [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Trail-Counters-Device-Locations/vxcr-pjs7). 

Also made some changes to start publishing the device ID and use that ID in the unique record ID.

[Trail Counter Daily totals](https://datahub.austintexas.gov/Transportation-and-Mobility/Trail-Counters-Daily-Totals/26tt-cp67) dataset